### PR TITLE
feat: adding any custom driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Golang's application config manage tool library.
 - Support multi format: `JSON`(default), `INI`, `YAML`, `TOML`, `HCL`, `ENV`, `Flags`
   - `JSON` content support comments. will auto clear comments
   - Other drivers are used on demand, not used will not be loaded into the application.
+	- Possibility to add custom driver for your specific format
 - Support multi-file and multi-data loading
 - Support loading configuration from os ENV
 - Support for loading configuration data from remote URLs

--- a/load.go
+++ b/load.go
@@ -295,18 +295,6 @@ func (c *Config) parseSourceCode(format string, blob []byte) (err error) {
 	return
 }
 
-func (c *Config) getDecoderByFormat(format string) (decoder Decoder) {
-	switch format {
-	case Hcl:
-		decoder = c.decoders[Hcl]
-	case Ini:
-		decoder = c.decoders[Ini]
-	case JSON:
-		decoder = c.decoders[JSON]
-	case Yaml, Yml:
-		decoder = c.decoders[Yaml]
-	case Toml:
-		decoder = c.decoders[Toml]
-	}
-	return
+func (c *Config) getDecoderByFormat(format string) Decoder {
+	return c.decoders[format]
 }

--- a/other/other.go
+++ b/other/other.go
@@ -1,0 +1,37 @@
+/*
+Package other is an example of a custom driver
+*/
+package other
+
+import (
+	"github.com/gookit/config/v2"
+	"github.com/gookit/config/v2/ini"
+)
+
+const driverName = "other"
+
+var (
+	// Driver is the exported symbol
+	Driver = &otherDriver{}
+	// Encoder is the encoder for this driver
+	Encoder = ini.Encoder
+	// Decoder is the decoder for this driver
+	Decoder = ini.Decoder
+)
+
+type otherDriver struct{}
+
+// Name get name
+func (d *otherDriver) Name() string {
+	return driverName
+}
+
+// GetDecoder for other (same than ini)
+func (d *otherDriver) GetDecoder() config.Decoder {
+	return Decoder
+}
+
+// GetEncoder for other (same than ini)
+func (d *otherDriver) GetEncoder() config.Encoder {
+	return Encoder
+}

--- a/other/other_test.go
+++ b/other/other_test.go
@@ -1,0 +1,58 @@
+package other
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gookit/config/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOtherDriver(t *testing.T) {
+	st := assert.New(t)
+
+	st.Equal("other", Driver.Name())
+
+	c := config.NewEmpty("test")
+	st.False(c.HasDecoder("other"))
+
+	c.AddDriver(Driver)
+	st.True(c.HasDecoder("other"))
+	st.True(c.HasEncoder("other"))
+
+	_, err := Encoder(map[string]interface{}{"k": "v"})
+	st.Nil(err)
+
+	_, err = Encoder("invalid")
+	st.Error(err)
+}
+
+func TestOtherLoader(t *testing.T) {
+	config.AddDriver(Driver)
+
+	err := config.LoadFiles("../testdata/ini_base.other")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("get config example:\n")
+
+	name := config.String("name")
+	fmt.Printf("get string\n - val: %v\n", name)
+
+	map1 := config.StringMap("map1")
+	fmt.Printf("get map\n - val: %#v\n", map1)
+
+	val0 := config.String("map1.key")
+	fmt.Printf("get sub-value by path 'map.key'\n - val: %v\n", val0)
+
+	// can parse env name(ParseEnv: true)
+	fmt.Printf("get env 'envKey' val: %s\n", config.String("envKey", ""))
+	fmt.Printf("get env 'envKey1' val: %s\n", config.String("envKey1", ""))
+
+	// set value
+	_ = config.Set("name", "new name")
+	name = config.String("name")
+	fmt.Printf("set string\n - val: %v\n", name)
+
+}

--- a/testdata/ini_base.other
+++ b/testdata/ini_base.other
@@ -1,0 +1,11 @@
+name = app
+debug = false
+baseKey = value
+age = 123
+envKey = ${SHELL}
+envKey1 = ${NotExist|defValue}
+
+[map1]
+key = val
+key1 = val1
+key2 = val2


### PR DESCRIPTION
I saw that with a small change, gookit/config could load any custom driver, to be extendable to any format needed by users.

I have added a fake "other" driver which uses the ini code for the sake of example.