### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ func main() {
 
 ## Bind Structure
 
-> Note: The default binding mapping tag of a structure is `mapstructure`, which can be changed by setting `Options.TagName`
+> Note: The default binding mapping tag of a structure is `mapstructure`, which can be changed by setting the decoder's option `options.DecoderConfig.TagName`
 
 ```go
 user := struct {
@@ -116,7 +116,7 @@ fmt.Println(user.UserName) // inhere
 
 ```go
 config.WithOptions(func(opt *Options) {
-    opt.TagName = "config"
+    options.DecoderConfig.TagName = "config"
 })
 ```
 


### PR DESCRIPTION
`options.TagName` is deprecated, and as so, some editors would flag the field as deprecated, discouraging the user to use it.

I found some usages of `options.DecoderConfig.TagName` in some tests and believe the README should be updated.