### PR TITLE
Fix parsing structs that contain duration starting with 9

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -447,3 +447,4 @@ func TestMapStringStringParseEnv(t *testing.T) {
 		is.Eq(shellVal, sMap["key3"])
 	})
 }
+

--- a/issues_test.go
+++ b/issues_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 	"time"
+        "fmt"
 
 	"github.com/gookit/config/v2"
 	"github.com/gookit/config/v2/ini"
@@ -434,4 +435,29 @@ func TestIssues_146(t *testing.T) {
 	assert.Eq(t, 5*time.Second, cc.Env)
 	assert.Eq(t, 10*time.Second, cc.DefaultEnv)
 	assert.Eq(t, 15*time.Second, cc.NoEnv)
+}
+
+type DurationStruct struct {
+	Duration time.Duration
+}
+
+func TestDuration(t *testing.T) {
+	var (
+		err error
+		str string
+	)
+
+	c := config.New("test").WithOptions(config.ParseTime)
+	is := assert.New(t)
+	dur := DurationStruct{}
+
+	for _, seconds := range []int{10, 90} {
+		str = fmt.Sprintf(`{ "Duration": "%ds" }`, seconds)
+
+		err = c.LoadSources(config.JSON, []byte(str))
+		is.Nil(err)
+		err = c.Decode(&dur)
+		is.Nil(err)
+		is.Equal(float64(seconds), dur.Duration.Seconds())
+	}
 }

--- a/testdata/issues59.ini
+++ b/testdata/issues59.ini
@@ -1,4 +1,4 @@
-; exported at 2023-06-11 13:58:47
+; exported at 2023-07-01 14:46:07
 
 age = 123
 baseKey = value

--- a/util.go
+++ b/util.go
@@ -27,7 +27,7 @@ func ValDecodeHookFunc(parseEnv, parseTime bool) mapstructure.DecodeHookFunc {
 		}
 
 		// start char is number(1-9)
-		if str[0] > '0' && str[0] < '9' {
+		if str[0] > '0' && str[0] <= '9' {
 			// parse time string. eg: 10s
 			if parseTime && t.Kind() == reflect.Int64 {
 				dur, err := time.ParseDuration(str)


### PR DESCRIPTION
An example is `90s`