### PR TITLE
Fixed panic and bugs in Exists()/GetValue()

### DIFF
--- a/read.go
+++ b/read.go
@@ -63,19 +63,19 @@ func (c *Config) Exists(key string, findByPath ...bool) (ok bool) {
 			}
 		case []int: // is array(is from Set)
 			i, err := strconv.Atoi(k)
-			if err != nil || len(typeData) < i {
+			if err != nil || i >= len(typeData) {
 				return false
 			}
 			item = typeData[i]
 		case []string: // is array(is from Set)
 			i, err := strconv.Atoi(k)
-			if err != nil || len(typeData) < i {
+			if err != nil || i >= len(typeData) {
 				return false
 			}
 			item = typeData[i]
 		case []any: // is array(load from file)
 			i, err := strconv.Atoi(k)
-			if err != nil || len(typeData) < i {
+			if err != nil || i >= len(typeData) {
 				return false
 			}
 			item = typeData[i]
@@ -214,7 +214,7 @@ func (c *Config) GetValue(key string, findByPath ...bool) (value any, ok bool) {
 			i, err := strconv.Atoi(k)
 
 			// check slice index
-			if err != nil || len(typeData) < i {
+			if err != nil || len(typeData) <= i {
 				ok = false
 				c.addError(err)
 				return
@@ -223,7 +223,7 @@ func (c *Config) GetValue(key string, findByPath ...bool) (value any, ok bool) {
 			item = typeData[i]
 		case []string: // is array(is from Set)
 			i, err := strconv.Atoi(k)
-			if err != nil || len(typeData) < i {
+			if err != nil || len(typeData) <= i {
 				ok = false
 				c.addError(err)
 				return
@@ -232,7 +232,7 @@ func (c *Config) GetValue(key string, findByPath ...bool) (value any, ok bool) {
 			item = typeData[i]
 		case []any: // is array(load from file)
 			i, err := strconv.Atoi(k)
-			if err != nil || len(typeData) < i {
+			if err != nil || len(typeData) <= i {
 				ok = false
 				c.addError(err)
 				return

--- a/read.go
+++ b/read.go
@@ -63,21 +63,22 @@ func (c *Config) Exists(key string, findByPath ...bool) (ok bool) {
 			}
 		case []int: // is array(is from Set)
 			i, err := strconv.Atoi(k)
-
-			// check slice index
 			if err != nil || len(typeData) < i {
 				return false
 			}
+			item = typeData[i]
 		case []string: // is array(is from Set)
 			i, err := strconv.Atoi(k)
 			if err != nil || len(typeData) < i {
 				return false
 			}
+			item = typeData[i]
 		case []any: // is array(load from file)
 			i, err := strconv.Atoi(k)
 			if err != nil || len(typeData) < i {
 				return false
 			}
+			item = typeData[i]
 		default: // error
 			return false
 		}


### PR DESCRIPTION
I found several bugs in `Exists()` and `GetValue()`. The following test results in panics instead of finding the entries or returning expected results:
```
package main

import (
	"fmt"

	"github.com/gookit/config/v2"
	"github.com/gookit/config/v2/yaml"
)

type test struct {
	expected bool
	path     string
}

func run_test(t test) {
	var at_func string
	defer func() {
		if recover() != nil {
			fmt.Printf("[PANIC!] %s (at %s)\n", t.path, at_func)
		}
	}()

	result := "FAILED"
	at_func = "Exists"
	exists := config.Exists(t.path)
	at_func = "GetValue"
	v, ok := config.GetValue(t.path)
	if exists == t.expected && ok == t.expected {
		result = "  OK  "
	}
	fmt.Printf("[%s] %s: Exists() = %v ; GetValue() = (%v, %v)\n", result, t.path, exists, v, ok)

}

func main() {
	// config.ParseEnv: will parse env var in string value. eg: shell: ${SHELL}
	config.WithOptions(config.ParseEnv)

	// add driver for support yaml content
	config.AddDriver(yaml.Driver)

	yamlConfig := `
app:
  name: MyApp
  version: 1.0.0
lol:
  - test:
      bu: 1
      ba: ugly
      foo:
        - 1
        - 2
        - 3
  - another:
      - "pingu"
      - "pangu"
    gajo: nil
`

	err := config.LoadStrings(config.Yaml, yamlConfig)
	if err != nil {
		panic(err)
	}

	for _, t := range []test{
		{true, "lol"},
		{true, "lol.0"},
		{true, "lol.0.test.ba"},
		{true, "lol.0.test.foo"},
		{true, "lol.0.test.foo.0"},
		{true, "lol.0.test.foo.1"},
		{true, "lol.1.another.0"},
		{true, "lol.1.another.1"},
		{false, "lol.1.another.2"},
		{true, "lol.1.gajo"},
		{false, "lol.2"},
		{false, "lol.2.wat"},
	} {
		run_test(t)
	}
}
```
This small contribution/patch should fix this unexpected behavior.