### PR TITLE
fix(read): Duration() parses Go duration strings (e.g. "300s", "1h30m")

### DIFF
--- a/read.go
+++ b/read.go
@@ -377,14 +377,33 @@ func (c *Config) tryInt64(key string) (value int64, ok bool) {
 // Duration get a time.Duration type value. if not found return default value
 func Duration(key string, defVal ...time.Duration) time.Duration { return dc.Duration(key, defVal...) }
 
-// Duration get a time.Duration type value. if not found return default value
+// Duration get a time.Duration type value. if not found return default value.
+//
+// The stored value may be a Go duration string (e.g. "300s", "1h30m", "20m").
+// A bare integer is treated as nanoseconds for backwards compatibility.
 func (c *Config) Duration(key string, defVal ...time.Duration) time.Duration {
-	value, exist := c.tryInt64(key)
+	str, exist := c.getString(key)
+	if !exist {
+		if len(defVal) > 0 {
+			return defVal[0]
+		}
+		return 0
+	}
 
-	if !exist && len(defVal) > 0 {
+	// Prefer a Go duration string, e.g. "300s", "1h30m".
+	if dur, err := time.ParseDuration(str); err == nil {
+		return dur
+	}
+
+	// Backwards compatible: a bare integer is nanoseconds.
+	if n, err := strconv.ParseInt(str, 10, 64); err == nil {
+		return time.Duration(n)
+	}
+
+	if len(defVal) > 0 {
 		return defVal[0]
 	}
-	return time.Duration(value)
+	return 0
 }
 
 // Float get a float64 value, if not found return default value

--- a/read_test.go
+++ b/read_test.go
@@ -473,3 +473,29 @@ func TestParseEnv(t *testing.T) {
 		is.Eq("abc/", cfg.String("ekey4"))
 	})
 }
+
+func TestConfig_Duration_getter(t *testing.T) {
+	is := assert.New(t)
+	c := New("test")
+	err := c.LoadStrings(JSON, `{
+		"ttl": "300s",
+		"idle": "1h30m",
+		"short": "20m",
+		"nanos": 500,
+		"bad": "not-a-duration"
+	}`)
+	is.Nil(err)
+
+	// Go duration strings are parsed.
+	is.Eq(300*time.Second, c.Duration("ttl"))
+	is.Eq(90*time.Minute, c.Duration("idle"))
+	is.Eq(20*time.Minute, c.Duration("short"))
+
+	// A bare integer stays nanoseconds (backwards compatible).
+	is.Eq(time.Duration(500), c.Duration("nanos"))
+
+	// Unparseable and missing fall back to the default.
+	is.Eq(5*time.Minute, c.Duration("bad", 5*time.Minute))
+	is.Eq(7*time.Second, c.Duration("missing", 7*time.Second))
+	is.Eq(time.Duration(0), c.Duration("missing"))
+}


### PR DESCRIPTION
The `Config.Duration` getter reads the value as an `int64` and returns `time.Duration(n)` — i.e. **nanoseconds** — so:

- a duration string like `"300s"` cannot be read at all: it fails integer parsing and yields `0` (not even the default);
- a bare number like `300` is interpreted as `300ns`.

Duration-string parsing existed only on the struct-binding path (the `ParseTime` decode hook via `reflects.ToTimeOrDuration`), never on the `Duration()` getter — so `config.Duration("ttl")` on a `ttl: 300s` value silently returns the wrong result.

This parses the stored value as a Go duration string first (`time.ParseDuration`), falling back to the previous int64-nanoseconds behaviour for bare integers, then to the default:

```go
func (c *Config) Duration(key string, defVal ...time.Duration) time.Duration {
	str, exist := c.getString(key)
	if !exist {
		if len(defVal) > 0 { return defVal[0] }
		return 0
	}
	if dur, err := time.ParseDuration(str); err == nil { // "300s", "1h30m", ...
		return dur
	}
	if n, err := strconv.ParseInt(str, 10, 64); err == nil { // bare int = nanoseconds (unchanged)
		return time.Duration(n)
	}
	if len(defVal) > 0 { return defVal[0] }
	return 0
}
```

**Backwards compatible**: bare integers keep their nanosecond meaning; only previously-unreadable duration strings change (from `0`/error to the parsed value). No existing test asserted the old getter behaviour (the existing `TestDuration` covers the `Decode`/`ParseTime` path). Adds a getter test covering `"300s"`/`"1h30m"`/`"20m"`, a bare integer, and the malformed/missing default fallbacks. Full package test suite passes.